### PR TITLE
Use GitHub for plugin documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
     <name>PRQA plugin</name>
     <description>Integrates PRQA static analysis with Jenkins</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/PRQA+Plugin</url>
+    <url>https://github.com/jenkinsci/prqa-plugin</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jenkins.version>2.107.1</jenkins.version>


### PR DESCRIPTION
See details in [Jenkins docs](https://www.jenkins.io/doc/developer/publishing/documentation/#documenting-plugins)